### PR TITLE
sdl: Remove duplicated object

### DIFF
--- a/src/gpu/sdl/lv_gpu_sdl.mk
+++ b/src/gpu/sdl/lv_gpu_sdl.mk
@@ -4,7 +4,6 @@ CSRCS += lv_gpu_sdl_draw_img.c
 CSRCS += lv_gpu_sdl_draw_label.c
 CSRCS += lv_gpu_sdl_draw_line.c
 CSRCS += lv_gpu_sdl_draw_rect.c
-CSRCS += lv_gpu_sdl_texture_cache.c
 CSRCS += lv_gpu_sdl_lru.c
 CSRCS += lv_gpu_sdl_mask.c
 CSRCS += lv_gpu_sdl_stack_blur.c


### PR DESCRIPTION
Observed issue:

  /usr/bin/ld: lv_gpu_sdl_texture_cache.o: \
  in function `_lv_gpu_sdl_texture_cache_init':
  lv_gpu_sdl_texture_cache.c:(.text+0x30): \
  multiple definition of `_lv_gpu_sdl_texture_cache_init'; \
  lv_gpu_sdl_texture_cache.o:lv_gpu_sdl_texture_cache.c:(.text+0x30): \
  first defined here

Signed-off-by: Philippe Coval <philippe.coval@huawei.com>

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Update [CHANGELOG.md](https://github.com/lvgl/lvgl/blob/master/docs/CHANGELOG.md)
- [ ] Update the documentation
